### PR TITLE
typo error LSR2 instead of LSR3

### DIFF
--- a/nnet/datasets.py
+++ b/nnet/datasets.py
@@ -565,7 +565,7 @@ class LRS(Dataset):
 
         if self.version == "LRS2":
             paths_txt = glob.glob(os.path.join(self.root, "LRS2", "*", "*", "*", "*.txt"))
-        elif self.version == "LRS2":
+        elif self.version == "LRS3":
             paths_txt = glob.glob(os.path.join(self.root, "LRS3", "*", "*", "*.txt"))
 
         # Create Corpus File


### PR DESCRIPTION
when passing LSR3 still the prepare dataset is processing LSR2 instead of LSR3. The bug source is typo.